### PR TITLE
Fetch transaction summary for fees

### DIFF
--- a/coinbase/rest/fees.py
+++ b/coinbase/rest/fees.py
@@ -1,0 +1,38 @@
+from typing import Any, Dict, Optional
+
+from coinbase.constants import API_PREFIX
+from coinbase.rest.types.fees_types import GetTransactionSummaryResponse
+
+
+def get_transaction_summary(
+    self,
+    product_type: Optional[str] = None,
+    contract_expiry_type: Optional[str] = None,
+    product_venue: Optional[str] = None,
+    **kwargs,
+) -> GetTransactionSummaryResponse:
+    """
+    **Get Transactions Summary**
+    _____________________________
+
+    [GET] https://api.coinbase.com/api/v3/brokerage/transaction_summary
+
+    __________
+
+    **Description:**
+
+    Get a summary of transactions with fee tiers, total volume, and fees.
+
+    __________
+
+    **Read more on the official documentation:** `Get Transaction Summary <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_gettransactionsummary>`_
+    """
+    endpoint = f"{API_PREFIX}/transaction_summary"
+
+    params = {
+        "product_type": product_type,
+        "contract_expiry_type": contract_expiry_type,
+        "product_venue": product_venue,
+    }
+
+    return GetTransactionSummaryResponse(self.get(endpoint, params=params, **kwargs))


### PR DESCRIPTION
Add `get_transaction_summary` function to `coinbase/rest/fees.py` and fix a syntax error in its return statement.

---
<a href="https://cursor.com/background-agent?bcId=bc-ecb4ca5d-bf7f-4ee2-8a10-d531b65e4f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ecb4ca5d-bf7f-4ee2-8a10-d531b65e4f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

